### PR TITLE
Fix extension buttons detection

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,9 +1,7 @@
 async function hideMergeButtons(details) {
-    await chrome.tabs.sendMessage(details.tabId, {});
+  await chrome.tabs.sendMessage(details.tabId, {});
 }
 
 chrome.webRequest.onCompleted.addListener(hideMergeButtons, {
-    urls: [
-        "https://github.com/*/*/pull/*/partials/merging"
-    ]
+  urls: ["https://github.com/*/*/pull/*/page_data/status_checks"],
 });

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,42 +1,83 @@
 (() => {
-    chrome.runtime.onMessage.addListener(chromeMessageListener);
+  chrome.runtime.onMessage.addListener(chromeMessageListener);
 })();
 
 async function chromeMessageListener(request, sender, sendResponse) {
-    // TODO: Check how can we avoid duplicating this
-    if (/^https:\/\/github\.com\/[\w-]+\/[\w-]+\/pull\//.test(location.href)) {
-        await onButtonsLoaded();
-    }
+  // TODO: Check how can we avoid duplicating this
+  if (/^https:\/\/github\.com\/[\w-]+\/[\w-]+\/pull\//.test(location.href)) {
+    await onButtonsLoaded();
+  }
 }
 
 async function onButtonsLoaded() {
-    const prStatus = document.querySelectorAll("[reviewable_state]")[0].innerText
+  const prStatus = document.querySelectorAll("[reviewable_state]")[0].innerText;
 
-    if (prStatus.includes("Open")) {
-        const basePRMessage = document.getElementsByClassName("flex-auto min-width-0 mb-2")[0].children
-        // Position 2 is target branch and position 5 is source branch
-        const targetBranch = basePRMessage[2].children[0].children[0].innerText
+  if (prStatus.includes("Open")) {
+    const basePRMessage = document.getElementsByClassName(
+      "flex-auto min-width-0 mb-2"
+    )[0].children;
+    // Position 2 is target branch and position 5 is source branch
+    const targetBranch = basePRMessage[2].children[0].children[0].innerText;
 
-        chrome.storage.sync.get(["branchNameRegex"]).then(({ branchNameRegex = "main" }) => {
-            if (targetBranch.match(branchNameRegex)) {
-                hideButtons();
-            }
-        });
-    }
+    chrome.storage.sync
+      .get(["branchNameRegex"])
+      .then(({ branchNameRegex = "main" }) => {
+        if (targetBranch.match(branchNameRegex)) {
+          hideButtons();
+        }
+      });
+  }
 }
 
 function hideButtons() {
-    // This one is the actual merge button
-    const mergeButtonDefault = document.getElementsByClassName("btn-group-squash")
-    hideAll(mergeButtonDefault)
+  // This one is the actual merge button
+  const mergeButtonDefault = document.getElementsByClassName(
+    "prc-Button-ButtonBase-c50BI flex-1"
+  );
+  const mergeButtonText = document.getElementsByClassName(
+    "prc-Button-Label-pTQ3x"
+  );
 
-    // This one is the one from the dropdown
-    const mergeButtonDropdown = document.getElementsByClassName("js-merge-box-button-squash")
-    hideAll(mergeButtonDropdown)
+  if (mergeButtonText[0].textContent.includes("Squash")) {
+    mergeButtonText[0].textContent =
+      mergeButtonText[0].textContent + " (disabled by extension)";
+    mergeButtonDefault[0].disabled = true;
+  }
+
+  // Listen for changes in button text
+  if (mergeButtonText[0]) {
+    const observer = new MutationObserver(() => {
+      if (mergeButtonText[0].textContent.includes("Squash")) {
+        if (
+          !mergeButtonText[0].textContent.includes("(disabled by extension)")
+        ) {
+          mergeButtonText[0].textContent =
+            mergeButtonText[0].textContent + " (disabled by extension)";
+        }
+        mergeButtonDefault[0].disabled = true;
+      } else {
+        mergeButtonDefault[0].disabled = false;
+      }
+    });
+
+    observer.observe(mergeButtonText[0], {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+  }
+
+  // This one is the one from the dropdown
+  const mergeButtonDropdownLegacy = document.getElementsByClassName(
+    "js-merge-box-button-squash"
+  );
+  hideAll(mergeButtonDropdownLegacy);
+  const mergeButtonDropdown = document.getElementById(":r3:");
+  hideAll(mergeButtonDropdown);
 }
 
 function hideAll(elements) {
-    for (let element of elements) {
-        element.style.display = "none"
-    }
+  for (let element of elements) {
+    element.style.display = "none";
+  }
 }

--- a/contentScript.js
+++ b/contentScript.js
@@ -38,24 +38,12 @@ function hideButtons() {
     "prc-Button-Label-pTQ3x"
   );
 
-  if (mergeButtonText[0].textContent.includes("Squash")) {
-    mergeButtonText[0].textContent += " (disabled by extension)";
-    mergeButtonDefault[0].disabled = true;
-  }
+  modifyMergeButton(mergeButtonDefault[0], mergeButtonText[0]);
 
   // Listen for changes in button text
   if (mergeButtonText[0]) {
     const observer = new MutationObserver(() => {
-      if (mergeButtonText[0].textContent.includes("Squash")) {
-        if (
-          !mergeButtonText[0].textContent.includes("(disabled by extension)")
-        ) {
-          mergeButtonText[0].textContent += " (disabled by extension)";
-        }
-        mergeButtonDefault[0].disabled = true;
-      } else {
-        mergeButtonDefault[0].disabled = false;
-      }
+      modifyMergeButton(mergeButtonDefault[0], mergeButtonText[0]);
     });
 
     observer.observe(mergeButtonText[0], {
@@ -66,8 +54,13 @@ function hideButtons() {
   }
 }
 
-function hideAll(elements) {
-  for (let element of elements) {
-    element.style.display = "none";
+function modifyMergeButton(mergeButtonDefault, mergeButtonText) {
+  if (mergeButtonText.textContent.includes("Squash")) {
+    if (!mergeButtonText.textContent.includes("(disabled by extension)")) {
+      mergeButtonText.textContent += " (disabled by extension)";
+    }
+    mergeButtonDefault.disabled = true;
+  } else {
+    mergeButtonDefault.disabled = false;
   }
 }

--- a/contentScript.js
+++ b/contentScript.js
@@ -66,14 +66,6 @@ function hideButtons() {
       characterData: true,
     });
   }
-
-  // This one is the one from the dropdown
-  const mergeButtonDropdownLegacy = document.getElementsByClassName(
-    "js-merge-box-button-squash"
-  );
-  hideAll(mergeButtonDropdownLegacy);
-  const mergeButtonDropdown = document.getElementById(":r3:");
-  hideAll(mergeButtonDropdown);
 }
 
 function hideAll(elements) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -39,8 +39,7 @@ function hideButtons() {
   );
 
   if (mergeButtonText[0].textContent.includes("Squash")) {
-    mergeButtonText[0].textContent =
-      mergeButtonText[0].textContent + " (disabled by extension)";
+    mergeButtonText[0].textContent += " (disabled by extension)";
     mergeButtonDefault[0].disabled = true;
   }
 
@@ -51,8 +50,7 @@ function hideButtons() {
         if (
           !mergeButtonText[0].textContent.includes("(disabled by extension)")
         ) {
-          mergeButtonText[0].textContent =
-            mergeButtonText[0].textContent + " (disabled by extension)";
+          mergeButtonText[0].textContent += " (disabled by extension)";
         }
         mergeButtonDefault[0].disabled = true;
       } else {

--- a/options/options.html
+++ b/options/options.html
@@ -1,16 +1,62 @@
 <!DOCTYPE html>
 <html>
-<head><title>GitHub S&M Blocker</title></head>
-<link href="options.css" rel="stylesheet" type="text/css"/>
-<body>
+  <head>
+    <title>GitHub S&M Blocker</title>
+    <link href="options.css" rel="stylesheet" type="text/css" />
+  </head>
+  <body style="background: #f7f7f9; font-family: system-ui, sans-serif">
+    <div
+      style="
+        max-width: 370px;
+        margin: 40px auto;
+        padding: 24px 20px;
+        background: #fff;
+        border-radius: 10px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+      "
+    >
+      <h2 style="margin-top: 0; margin-bottom: 14px; font-size: 1.3em">
+        Configurations
+      </h2>
+      <label
+        for="branchNameRegex"
+        style="display: block; margin-bottom: 8px; font-weight: 500"
+      >
+        Branch to hide the button for
+        <span style="color: #888">(supports regex)</span>:
+      </label>
+      <input
+        type="text"
+        id="branchNameRegex"
+        name="name"
+        required
+        style="
+          width: 100%;
+          padding: 8px 10px;
+          margin-bottom: 16px;
+          border: 1px solid #ccc;
+          border-radius: 5px;
+          font-size: 1em;
+          box-sizing: border-box;
+        "
+      />
+      <div id="status" style="margin-bottom: 12px; color: #2a7"></div>
+      <button
+        id="save"
+        style="
+          padding: 8px 18px;
+          background: #0057d8;
+          color: #fff;
+          border: none;
+          border-radius: 5px;
+          font-size: 1em;
+          cursor: pointer;
+        "
+      >
+        Save
+      </button>
+    </div>
 
-<h2>Configurations</h2>
-<p>Branch to hide the button for (supports regex):</p>
-<input type="text" id="branchNameRegex" name="name" required>
-
-<div id="status"></div>
-<button id="save">Save</button>
-
-<script src="options.js"></script>
-</body>
+    <script src="options.js"></script>
+  </body>
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -9,14 +9,21 @@ document.addEventListener("DOMContentLoaded", async () => {
       .get(["branchNameRegex"])
       .then(({ branchNameRegex = "main" }) => {
         container.innerHTML = `
-                    <div class="title">
-                        Squash & merge is going to be blocked if the PR is open.
-                        </br>
-                        </br>
-                        <div class="subtitle">
-                        The current branch name regex is: <a href="chrome-extension://aabhjeaepficccegjneggegjjcegnhel/options/options.html"><code>${branchNameRegex}</code></a>
-                        </div>
-                    </div>`;
+    <div style="padding:18px 14px;">
+      <div class="title" style="font-size:1.2em;font-weight:bold;margin-bottom:10px;">
+        🚫 Squash &amp; Merge Blocked
+      </div>
+      <div class="description" style="margin-bottom:18px; color:#333;">
+        If this PR is open, squash &amp; merge will be blocked.
+      </div>
+      <div class="subtitle" style="font-size:0.97em;color:#555;margin-bottom:8px;">
+        <span>Current branch name regex:</span>
+        <a href="chrome-extension://aabhjeaepficccegjneggegjjcegnhel/options/options.html" style="text-decoration:none;">
+          <code style="background:#f5f5f5;padding:3px 8px;border-radius:5px;font-size:0.98em;">${branchNameRegex}</code>
+        </a>
+      </div>
+    </div>
+  `;
       });
   } else {
     container.innerHTML =

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,23 +1,25 @@
-import {getActiveTabURL, isGitHubPrTab} from "./utils.js";
+import { getActiveTabURL, isGitHubPrTab } from "./utils.js";
 
 document.addEventListener("DOMContentLoaded", async () => {
-        const activeTab = await getActiveTabURL();
+  const activeTab = await getActiveTabURL();
 
-        const container = document.getElementsByClassName("container")[0];
-        if (isGitHubPrTab(activeTab)) {
-            chrome.storage.sync.get(["branchNameRegex"]).then(({branchNameRegex = "main"}) => {
-                container.innerHTML = `
+  const container = document.getElementsByClassName("container")[0];
+  if (isGitHubPrTab(activeTab)) {
+    chrome.storage.sync
+      .get(["branchNameRegex"])
+      .then(({ branchNameRegex = "main" }) => {
+        container.innerHTML = `
                     <div class="title">
                         Squash & merge is going to be blocked if the PR is open.
                         </br>
                         </br>
                         <div class="subtitle">
-                        The current branch name regex is: <code>${branchNameRegex}</code>
+                        The current branch name regex is: <a href="chrome-extension://aabhjeaepficccegjneggegjjcegnhel/options/options.html"><code>${branchNameRegex}</code></a>
                         </div>
                     </div>`;
-            });
-        } else {
-            container.innerHTML = '<div class="title">This is not a GitHub PR page</div>';
-        }
-    }
-);
+      });
+  } else {
+    container.innerHTML =
+      '<div class="title">This is not a GitHub PR page</div>';
+  }
+});


### PR DESCRIPTION
The group names used to detect and hide the buttons changed, so the buttons were no longer being detected.

To fix this, I looked up the new group names and discovered that the HTML structure had also changed. There is now no dedicated button for the Squash & Merge option. To provide the same user experience, the extension now checks if the selected option is Squash & Merge and disables the button accordingly.

Additionally, I added a link in the extension popup that allows editing the branch name.


https://github.com/user-attachments/assets/2fe6f1dd-ad97-49a6-b15c-eaa70873a345

